### PR TITLE
【アカウント】アカウント名の更新に認証を追加

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -247,6 +247,9 @@ components:
                 properties:
                   name:
                     readOnly: true
+                  new_password:
+                    type: "string"
+                    example: "password"
     login:
       required: true
       content:

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -234,8 +234,6 @@ components:
               - $ref: "#/components/schemas/account"
               - type: "object"
                 properties:
-                  password:
-                    readOnly: true
                   confirm_password:
                     readOnly: true
     update_account_password:

--- a/internal/app/api/interface/handler/account.go
+++ b/internal/app/api/interface/handler/account.go
@@ -69,7 +69,7 @@ func (h *accountHandler) UpdateName(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
-	account, err := h.accountUC.UpdateName(ctx, accountID, req.Name)
+	account, err := h.accountUC.UpdateName(ctx, accountID, req.Password, req.Name)
 	if err != nil {
 		log.Println(err)
 		errors.Handle(c, err)

--- a/internal/app/api/interface/handler/account.go
+++ b/internal/app/api/interface/handler/account.go
@@ -96,7 +96,7 @@ func (h *accountHandler) UpdatePassword(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
-	account, err := h.accountUC.UpdatePassword(ctx, accountID, req.Password, req.ConfirmPassword)
+	account, err := h.accountUC.UpdatePassword(ctx, accountID, req.Password, req.NewPassword, req.ConfirmPassword)
 	if err != nil {
 		log.Println(err)
 		errors.Handle(c, err)

--- a/internal/app/api/interface/handler/account_test.go
+++ b/internal/app/api/interface/handler/account_test.go
@@ -126,7 +126,7 @@ func TestAccount_UpdateName(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			requestJSON:    []byte(`{"name": "name"}`),
+			requestJSON:    []byte(`{"password": "password", "name": "name"}`),
 			isSetAccountID: true,
 			expectCode:     http.StatusOK,
 			expectResponse: map[string]any{"name": "name"},
@@ -156,7 +156,7 @@ func TestAccount_UpdateName(t *testing.T) {
 		},
 		{
 			name:           "update error",
-			requestJSON:    []byte(`{"name": "name"}`),
+			requestJSON:    []byte(`{"password": "password", "name": "name"}`),
 			isSetAccountID: true,
 			expectCode:     http.StatusConflict,
 			expectResponse: map[string]any{"message": "conflict"},
@@ -229,14 +229,14 @@ func TestAccount_UpdatePassword(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			requestJSON:    []byte(`{"password": "password", "confirm_password": "password"}`),
+			requestJSON:    []byte(`{"password": "password", "new_password": "password", "confirm_password": "password"}`),
 			isSetAccountID: true,
 			expectCode:     http.StatusOK,
 			expectResponse: map[string]any{"name": "name"},
 			setMockAccountUC: func(ctx context.Context, accountUC *usecase.MockAccountUsecase) {
 				accountUC.
 					EXPECT().
-					UpdatePassword(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
+					UpdatePassword(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(accountDTO, nil).
 					Times(1)
 			},
@@ -259,14 +259,14 @@ func TestAccount_UpdatePassword(t *testing.T) {
 		},
 		{
 			name:           "update error",
-			requestJSON:    []byte(`{"password": "password", "confirm_password": "password"}`),
+			requestJSON:    []byte(`{"password": "password", "new_password": "password", "confirm_password": "password"}`),
 			isSetAccountID: true,
 			expectCode:     http.StatusUnauthorized,
 			expectResponse: map[string]any{"message": "unauthorized"},
 			setMockAccountUC: func(ctx context.Context, accountUC *usecase.MockAccountUsecase) {
 				accountUC.
 					EXPECT().
-					UpdatePassword(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
+					UpdatePassword(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, status.ErrUnauthorized).
 					Times(1)
 			},

--- a/internal/app/api/interface/handler/account_test.go
+++ b/internal/app/api/interface/handler/account_test.go
@@ -133,7 +133,7 @@ func TestAccount_UpdateName(t *testing.T) {
 			setMockAccountUC: func(ctx context.Context, accountUC *usecase.MockAccountUsecase) {
 				accountUC.
 					EXPECT().
-					UpdateName(ctx, gomock.Any(), gomock.Any()).
+					UpdateName(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(accountDTO, nil).
 					Times(1)
 			},
@@ -163,7 +163,7 @@ func TestAccount_UpdateName(t *testing.T) {
 			setMockAccountUC: func(ctx context.Context, accountUC *usecase.MockAccountUsecase) {
 				accountUC.
 					EXPECT().
-					UpdateName(ctx, gomock.Any(), gomock.Any()).
+					UpdateName(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, status.ErrConflict).
 					Times(1)
 			},

--- a/internal/app/api/interface/schema/account.go
+++ b/internal/app/api/interface/schema/account.go
@@ -7,7 +7,8 @@ type CreateAccountRequest struct {
 }
 
 type UpdateAccountNameRequest struct {
-	Name string `json:"name"`
+	Password string `json:"password"`
+	Name     string `json:"name"`
 }
 
 type UpdateAccountPasswordRequest struct {

--- a/internal/app/api/interface/schema/account.go
+++ b/internal/app/api/interface/schema/account.go
@@ -13,7 +13,7 @@ type UpdateAccountNameRequest struct {
 
 type UpdateAccountPasswordRequest struct {
 	Password        string `json:"password"`
-	NewPassword     string `json:"new_passaword"`
+	NewPassword     string `json:"new_password"`
 	ConfirmPassword string `json:"confirm_password"`
 }
 

--- a/internal/app/api/interface/schema/account.go
+++ b/internal/app/api/interface/schema/account.go
@@ -13,6 +13,7 @@ type UpdateAccountNameRequest struct {
 
 type UpdateAccountPasswordRequest struct {
 	Password        string `json:"password"`
+	NewPassword     string `json:"new_passaword"`
 	ConfirmPassword string `json:"confirm_password"`
 }
 

--- a/internal/app/api/usecase/account.go
+++ b/internal/app/api/usecase/account.go
@@ -17,7 +17,7 @@ import (
 
 type AccountUsecase interface {
 	Create(context.Context, string, string, string) (*dto.AccountDTO, error)
-	UpdateName(context.Context, uuid.UUID, string) (*dto.AccountDTO, error)
+	UpdateName(context.Context, uuid.UUID, string, string) (*dto.AccountDTO, error)
 	UpdatePassword(context.Context, uuid.UUID, string, string) (*dto.AccountDTO, error)
 	Delete(context.Context, uuid.UUID) error
 }
@@ -59,7 +59,7 @@ func (u *accountUsecase) Create(ctx context.Context, name, password, confirmPass
 	return mapper.ToAccountDTO(account), nil
 }
 
-func (u *accountUsecase) UpdateName(ctx context.Context, id uuid.UUID, name string) (*dto.AccountDTO, error) {
+func (u *accountUsecase) UpdateName(ctx context.Context, id uuid.UUID, password, name string) (*dto.AccountDTO, error) {
 	var account *entity.Account
 
 	if err := u.transactionObj.Transaction(ctx, func(ctx context.Context) error {
@@ -70,6 +70,10 @@ func (u *accountUsecase) UpdateName(ctx context.Context, id uuid.UUID, name stri
 		}
 		if account == nil {
 			return status.ErrUnauthorized
+		}
+
+		if err := account.ComparePassword(password); err != nil {
+			return err
 		}
 
 		if account.Name == name {

--- a/internal/app/api/usecase/account.go
+++ b/internal/app/api/usecase/account.go
@@ -18,7 +18,7 @@ import (
 type AccountUsecase interface {
 	Create(context.Context, string, string, string) (*dto.AccountDTO, error)
 	UpdateName(context.Context, uuid.UUID, string, string) (*dto.AccountDTO, error)
-	UpdatePassword(context.Context, uuid.UUID, string, string) (*dto.AccountDTO, error)
+	UpdatePassword(context.Context, uuid.UUID, string, string, string) (*dto.AccountDTO, error)
 	Delete(context.Context, uuid.UUID) error
 }
 
@@ -96,7 +96,7 @@ func (u *accountUsecase) UpdateName(ctx context.Context, id uuid.UUID, password,
 	return mapper.ToAccountDTO(account), nil
 }
 
-func (u *accountUsecase) UpdatePassword(ctx context.Context, id uuid.UUID, password, confirmPassword string) (*dto.AccountDTO, error) {
+func (u *accountUsecase) UpdatePassword(ctx context.Context, id uuid.UUID, password, newPassword, confirmPassword string) (*dto.AccountDTO, error) {
 	var account *entity.Account
 
 	if err := u.transactionObj.Transaction(ctx, func(ctx context.Context) error {
@@ -109,7 +109,11 @@ func (u *accountUsecase) UpdatePassword(ctx context.Context, id uuid.UUID, passw
 			return status.ErrUnauthorized
 		}
 
-		if err := account.SetPassword(password, confirmPassword); err != nil {
+		if err := account.ComparePassword(password); err != nil {
+			return err
+		}
+
+		if err := account.SetPassword(newPassword, confirmPassword); err != nil {
 			return err
 		}
 

--- a/internal/app/api/usecase/account_test.go
+++ b/internal/app/api/usecase/account_test.go
@@ -195,6 +195,7 @@ func TestAccount_UpdateName(t *testing.T) {
 	tests := []struct {
 		name                  string
 		inputID               uuid.UUID
+		inputPassword         string
 		inputName             string
 		expectResult          *dto.AccountDTO
 		expectError           error
@@ -203,11 +204,12 @@ func TestAccount_UpdateName(t *testing.T) {
 		setMockAccountServ    func(context.Context, *service.MockAccountService)
 	}{
 		{
-			name:         "success",
-			inputID:      account.ID,
-			inputName:    "update",
-			expectResult: accountDTO,
-			expectError:  nil,
+			name:          "success",
+			inputID:       account.ID,
+			inputPassword: "password",
+			inputName:     "update",
+			expectResult:  accountDTO,
+			expectError:   nil,
 			setMockTransactionObj: func(ctx context.Context, transactionObj *transaction.MockTransactionObject) {
 				transactionObj.
 					EXPECT().
@@ -238,11 +240,12 @@ func TestAccount_UpdateName(t *testing.T) {
 			},
 		},
 		{
-			name:         "name not changed",
-			inputID:      account.ID,
-			inputName:    "update",
-			expectResult: accountDTO,
-			expectError:  nil,
+			name:          "authentication failed",
+			inputID:       account.ID,
+			inputPassword: "PASSWORD",
+			inputName:     "update",
+			expectResult:  nil,
+			expectError:   status.ErrUnauthorized,
 			setMockTransactionObj: func(ctx context.Context, transactionObj *transaction.MockTransactionObject) {
 				transactionObj.
 					EXPECT().
@@ -262,11 +265,12 @@ func TestAccount_UpdateName(t *testing.T) {
 			setMockAccountServ: func(context.Context, *service.MockAccountService) {},
 		},
 		{
-			name:         "invalid name",
-			inputID:      account.ID,
-			inputName:    "",
-			expectResult: nil,
-			expectError:  status.ErrBadRequest,
+			name:          "name not changed",
+			inputID:       account.ID,
+			inputPassword: "password",
+			inputName:     "update",
+			expectResult:  accountDTO,
+			expectError:   nil,
 			setMockTransactionObj: func(ctx context.Context, transactionObj *transaction.MockTransactionObject) {
 				transactionObj.
 					EXPECT().
@@ -286,11 +290,37 @@ func TestAccount_UpdateName(t *testing.T) {
 			setMockAccountServ: func(context.Context, *service.MockAccountService) {},
 		},
 		{
-			name:         "account already exists",
-			inputID:      account.ID,
-			inputName:    "name",
-			expectResult: nil,
-			expectError:  status.ErrConflict,
+			name:          "invalid name",
+			inputID:       account.ID,
+			inputPassword: "password",
+			inputName:     "",
+			expectResult:  nil,
+			expectError:   status.ErrBadRequest,
+			setMockTransactionObj: func(ctx context.Context, transactionObj *transaction.MockTransactionObject) {
+				transactionObj.
+					EXPECT().
+					Transaction(ctx, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, fn func(context.Context) error) error {
+						return fn(ctx)
+					}).
+					Times(1)
+			},
+			setMockAccountRepo: func(ctx context.Context, accountRepo *repository.MockAccountRepository) {
+				accountRepo.
+					EXPECT().
+					FindOneByID(ctx, gomock.Any()).
+					Return(account, nil).
+					Times(1)
+			},
+			setMockAccountServ: func(context.Context, *service.MockAccountService) {},
+		},
+		{
+			name:          "account already exists",
+			inputID:       account.ID,
+			inputPassword: "password",
+			inputName:     "name",
+			expectResult:  nil,
+			expectError:   status.ErrConflict,
 			setMockTransactionObj: func(ctx context.Context, transactionObj *transaction.MockTransactionObject) {
 				transactionObj.
 					EXPECT().
@@ -316,11 +346,12 @@ func TestAccount_UpdateName(t *testing.T) {
 			},
 		},
 		{
-			name:         "find error",
-			inputID:      account.ID,
-			inputName:    "name",
-			expectResult: nil,
-			expectError:  sql.ErrConnDone,
+			name:          "find error",
+			inputID:       account.ID,
+			inputPassword: "password",
+			inputName:     "name",
+			expectResult:  nil,
+			expectError:   sql.ErrConnDone,
 			setMockTransactionObj: func(ctx context.Context, transactionObj *transaction.MockTransactionObject) {
 				transactionObj.
 					EXPECT().
@@ -340,11 +371,12 @@ func TestAccount_UpdateName(t *testing.T) {
 			setMockAccountServ: func(context.Context, *service.MockAccountService) {},
 		},
 		{
-			name:         "update error",
-			inputID:      account.ID,
-			inputName:    "update",
-			expectResult: nil,
-			expectError:  sql.ErrConnDone,
+			name:          "update error",
+			inputID:       account.ID,
+			inputPassword: "password",
+			inputName:     "update",
+			expectResult:  nil,
+			expectError:   sql.ErrConnDone,
 			setMockTransactionObj: func(ctx context.Context, transactionObj *transaction.MockTransactionObject) {
 				transactionObj.
 					EXPECT().
@@ -392,7 +424,7 @@ func TestAccount_UpdateName(t *testing.T) {
 			tt.setMockAccountServ(ctx, accountServ)
 
 			uc := usecase.NewAccountUsecase(transactionObj, accountRepo, accountServ)
-			result, err := uc.UpdateName(ctx, tt.inputID, tt.inputName)
+			result, err := uc.UpdateName(ctx, tt.inputID, tt.inputPassword, tt.inputName)
 			if !errors.Is(err, tt.expectError) {
 				t.Errorf("\nexpect: %v\ngot: %v", tt.expectError, err)
 			}

--- a/test/mock/usecase/account.go
+++ b/test/mock/usecase/account.go
@@ -87,16 +87,16 @@ func (mr *MockAccountUsecaseMockRecorder) UpdateName(arg0, arg1, arg2, arg3 any)
 }
 
 // UpdatePassword mocks base method.
-func (m *MockAccountUsecase) UpdatePassword(arg0 context.Context, arg1 uuid.UUID, arg2, arg3 string) (*dto.AccountDTO, error) {
+func (m *MockAccountUsecase) UpdatePassword(arg0 context.Context, arg1 uuid.UUID, arg2, arg3, arg4 string) (*dto.AccountDTO, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePassword", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UpdatePassword", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*dto.AccountDTO)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdatePassword indicates an expected call of UpdatePassword.
-func (mr *MockAccountUsecaseMockRecorder) UpdatePassword(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockAccountUsecaseMockRecorder) UpdatePassword(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePassword", reflect.TypeOf((*MockAccountUsecase)(nil).UpdatePassword), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePassword", reflect.TypeOf((*MockAccountUsecase)(nil).UpdatePassword), arg0, arg1, arg2, arg3, arg4)
 }

--- a/test/mock/usecase/account.go
+++ b/test/mock/usecase/account.go
@@ -72,18 +72,18 @@ func (mr *MockAccountUsecaseMockRecorder) Delete(arg0, arg1 any) *gomock.Call {
 }
 
 // UpdateName mocks base method.
-func (m *MockAccountUsecase) UpdateName(arg0 context.Context, arg1 uuid.UUID, arg2 string) (*dto.AccountDTO, error) {
+func (m *MockAccountUsecase) UpdateName(arg0 context.Context, arg1 uuid.UUID, arg2, arg3 string) (*dto.AccountDTO, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateName", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UpdateName", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*dto.AccountDTO)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateName indicates an expected call of UpdateName.
-func (mr *MockAccountUsecaseMockRecorder) UpdateName(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAccountUsecaseMockRecorder) UpdateName(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateName", reflect.TypeOf((*MockAccountUsecase)(nil).UpdateName), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateName", reflect.TypeOf((*MockAccountUsecase)(nil).UpdateName), arg0, arg1, arg2, arg3)
 }
 
 // UpdatePassword mocks base method.


### PR DESCRIPTION
# Issue
- close: #78 

# 確認事項
- 正常時にデータベースのレコードが更新されることを確認
- 認証失敗時にUnauthorizedが返却されることを確認
