### PR TITLE
【アカウント】パスワードの更新に認証を追加

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -247,6 +247,9 @@ components:
                 properties:
                   name:
                     readOnly: true
+                  new_password:
+                    type: "string"
+                    example: "password"
     login:
       required: true
       content:

--- a/internal/app/api/interface/handler/account.go
+++ b/internal/app/api/interface/handler/account.go
@@ -96,7 +96,7 @@ func (h *accountHandler) UpdatePassword(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
-	account, err := h.accountUC.UpdatePassword(ctx, accountID, req.Password, req.ConfirmPassword)
+	account, err := h.accountUC.UpdatePassword(ctx, accountID, req.Password, req.NewPassword, req.ConfirmPassword)
 	if err != nil {
 		log.Println(err)
 		errors.Handle(c, err)

--- a/internal/app/api/interface/handler/account_test.go
+++ b/internal/app/api/interface/handler/account_test.go
@@ -126,7 +126,7 @@ func TestAccount_UpdateName(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			requestJSON:    []byte(`{"name": "name"}`),
+			requestJSON:    []byte(`{"password": "password", "name": "name"}`),
 			isSetAccountID: true,
 			expectCode:     http.StatusOK,
 			expectResponse: map[string]any{"name": "name"},
@@ -156,7 +156,7 @@ func TestAccount_UpdateName(t *testing.T) {
 		},
 		{
 			name:           "update error",
-			requestJSON:    []byte(`{"name": "name"}`),
+			requestJSON:    []byte(`{"password": "password", "name": "name"}`),
 			isSetAccountID: true,
 			expectCode:     http.StatusConflict,
 			expectResponse: map[string]any{"message": "conflict"},
@@ -229,14 +229,14 @@ func TestAccount_UpdatePassword(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			requestJSON:    []byte(`{"password": "password", "confirm_password": "password"}`),
+			requestJSON:    []byte(`{"password": "password", "new_password": "password", "confirm_password": "password"}`),
 			isSetAccountID: true,
 			expectCode:     http.StatusOK,
 			expectResponse: map[string]any{"name": "name"},
 			setMockAccountUC: func(ctx context.Context, accountUC *usecase.MockAccountUsecase) {
 				accountUC.
 					EXPECT().
-					UpdatePassword(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
+					UpdatePassword(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(accountDTO, nil).
 					Times(1)
 			},
@@ -259,14 +259,14 @@ func TestAccount_UpdatePassword(t *testing.T) {
 		},
 		{
 			name:           "update error",
-			requestJSON:    []byte(`{"password": "password", "confirm_password": "password"}`),
+			requestJSON:    []byte(`{"password": "password", "new_password": "password", "confirm_password": "password"}`),
 			isSetAccountID: true,
 			expectCode:     http.StatusUnauthorized,
 			expectResponse: map[string]any{"message": "unauthorized"},
 			setMockAccountUC: func(ctx context.Context, accountUC *usecase.MockAccountUsecase) {
 				accountUC.
 					EXPECT().
-					UpdatePassword(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
+					UpdatePassword(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, status.ErrUnauthorized).
 					Times(1)
 			},

--- a/internal/app/api/interface/schema/account.go
+++ b/internal/app/api/interface/schema/account.go
@@ -13,7 +13,7 @@ type UpdateAccountNameRequest struct {
 
 type UpdateAccountPasswordRequest struct {
 	Password        string `json:"password"`
-	NewPassword     string `json:"new_passaword"`
+	NewPassword     string `json:"new_password"`
 	ConfirmPassword string `json:"confirm_password"`
 }
 

--- a/internal/app/api/interface/schema/account.go
+++ b/internal/app/api/interface/schema/account.go
@@ -13,6 +13,7 @@ type UpdateAccountNameRequest struct {
 
 type UpdateAccountPasswordRequest struct {
 	Password        string `json:"password"`
+	NewPassword     string `json:"new_passaword"`
 	ConfirmPassword string `json:"confirm_password"`
 }
 

--- a/internal/app/api/usecase/account.go
+++ b/internal/app/api/usecase/account.go
@@ -18,7 +18,7 @@ import (
 type AccountUsecase interface {
 	Create(context.Context, string, string, string) (*dto.AccountDTO, error)
 	UpdateName(context.Context, uuid.UUID, string, string) (*dto.AccountDTO, error)
-	UpdatePassword(context.Context, uuid.UUID, string, string) (*dto.AccountDTO, error)
+	UpdatePassword(context.Context, uuid.UUID, string, string, string) (*dto.AccountDTO, error)
 	Delete(context.Context, uuid.UUID) error
 }
 
@@ -96,7 +96,7 @@ func (u *accountUsecase) UpdateName(ctx context.Context, id uuid.UUID, password,
 	return mapper.ToAccountDTO(account), nil
 }
 
-func (u *accountUsecase) UpdatePassword(ctx context.Context, id uuid.UUID, password, confirmPassword string) (*dto.AccountDTO, error) {
+func (u *accountUsecase) UpdatePassword(ctx context.Context, id uuid.UUID, password, newPassword, confirmPassword string) (*dto.AccountDTO, error) {
 	var account *entity.Account
 
 	if err := u.transactionObj.Transaction(ctx, func(ctx context.Context) error {
@@ -109,7 +109,11 @@ func (u *accountUsecase) UpdatePassword(ctx context.Context, id uuid.UUID, passw
 			return status.ErrUnauthorized
 		}
 
-		if err := account.SetPassword(password, confirmPassword); err != nil {
+		if err := account.ComparePassword(password); err != nil {
+			return err
+		}
+
+		if err := account.SetPassword(newPassword, confirmPassword); err != nil {
 			return err
 		}
 

--- a/test/mock/usecase/account.go
+++ b/test/mock/usecase/account.go
@@ -87,16 +87,16 @@ func (mr *MockAccountUsecaseMockRecorder) UpdateName(arg0, arg1, arg2, arg3 any)
 }
 
 // UpdatePassword mocks base method.
-func (m *MockAccountUsecase) UpdatePassword(arg0 context.Context, arg1 uuid.UUID, arg2, arg3 string) (*dto.AccountDTO, error) {
+func (m *MockAccountUsecase) UpdatePassword(arg0 context.Context, arg1 uuid.UUID, arg2, arg3, arg4 string) (*dto.AccountDTO, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePassword", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UpdatePassword", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*dto.AccountDTO)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdatePassword indicates an expected call of UpdatePassword.
-func (mr *MockAccountUsecaseMockRecorder) UpdatePassword(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockAccountUsecaseMockRecorder) UpdatePassword(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePassword", reflect.TypeOf((*MockAccountUsecase)(nil).UpdatePassword), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePassword", reflect.TypeOf((*MockAccountUsecase)(nil).UpdatePassword), arg0, arg1, arg2, arg3, arg4)
 }


### PR DESCRIPTION
# Issue
- close: #79 

# 確認事項
- 正常時にデータベースのレコードが更新されることを確認
- 認証失敗時にUnauthorizedが返却されることを確認
