### PR TITLE
【アカウント】アカウントの削除に認証を追加

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -49,6 +49,8 @@ paths:
           required: true
           description: "セッショントークン"
           example: "Session 1Ty1HKTPKTt8xEi-_3HTbWf2SCHOdqOS"
+      requestBody:
+        $ref: "#/components/requestBodies/delete_account"
       responses:
         204:
           $ref: "#/components/responses/204"
@@ -248,6 +250,19 @@ components:
               - type: "object"
                 properties:
                   name:
+                    readOnly: true
+    delete_account:
+      required: true
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/account"
+              - type: "object"
+                properties:
+                  name:
+                    readOnly: true
+                  confirm_password:
                     readOnly: true
     login:
       required: true

--- a/internal/app/api/interface/handler/account.go
+++ b/internal/app/api/interface/handler/account.go
@@ -107,6 +107,13 @@ func (h *accountHandler) UpdatePassword(c *gin.Context) {
 }
 
 func (h *accountHandler) Delete(c *gin.Context) {
+	var req schema.DeleteAccountRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		log.Println(err)
+		errors.Handle(c, status.ErrBadRequest)
+		return
+	}
+
 	accountID, err := parameter.GetContextParameter[uuid.UUID](c, "accountID")
 	if err != nil {
 		log.Println(err)
@@ -116,7 +123,7 @@ func (h *accountHandler) Delete(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
-	if err := h.accountUC.Delete(ctx, accountID); err != nil {
+	if err := h.accountUC.Delete(ctx, accountID, req.Password); err != nil {
 		log.Println(err)
 		errors.Handle(c, err)
 		return

--- a/internal/app/api/interface/schema/account.go
+++ b/internal/app/api/interface/schema/account.go
@@ -17,6 +17,10 @@ type UpdateAccountPasswordRequest struct {
 	ConfirmPassword string `json:"confirm_password"`
 }
 
+type DeleteAccountRequest struct {
+	Password string `json:"password"`
+}
+
 type AccountResponse struct {
 	Name string `json:"name"`
 }

--- a/test/mock/usecase/account.go
+++ b/test/mock/usecase/account.go
@@ -58,17 +58,17 @@ func (mr *MockAccountUsecaseMockRecorder) Create(arg0, arg1, arg2, arg3 any) *go
 }
 
 // Delete mocks base method.
-func (m *MockAccountUsecase) Delete(arg0 context.Context, arg1 uuid.UUID) error {
+func (m *MockAccountUsecase) Delete(arg0 context.Context, arg1 uuid.UUID, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockAccountUsecaseMockRecorder) Delete(arg0, arg1 any) *gomock.Call {
+func (mr *MockAccountUsecaseMockRecorder) Delete(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAccountUsecase)(nil).Delete), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAccountUsecase)(nil).Delete), arg0, arg1, arg2)
 }
 
 // UpdateName mocks base method.


### PR DESCRIPTION
# Issue
- close: #80 

# 確認事項
- 正常時にデータベースのレコードが更新されることを確認
- 認証失敗時にUnauthorizedが返却されることを確認
