### PR TITLE
【セッション】有効期限切れのTokenで認証が成功する不具合の対応 

### DIFF
--- a/internal/app/api/domain/repository/session.go
+++ b/internal/app/api/domain/repository/session.go
@@ -13,5 +13,5 @@ type SessionRepository interface {
 	Save(context.Context, *entity.Session) error
 	Delete(context.Context, *entity.Session) error
 	FindOneByAccountID(context.Context, uuid.UUID) (*entity.Session, error)
-	FindOneByToken(context.Context, string) (*entity.Session, error)
+	FindOneByTokenAndNotExpired(context.Context, string) (*entity.Session, error)
 }

--- a/internal/app/api/infrastructure/database/session.go
+++ b/internal/app/api/infrastructure/database/session.go
@@ -62,10 +62,10 @@ func (r *sessionRepository) FindOneByAccountID(ctx context.Context, accountID uu
 	return transformer.ToSessionEntity(&model), nil
 }
 
-func (r *sessionRepository) FindOneByToken(ctx context.Context, token string) (*entity.Session, error) {
+func (r *sessionRepository) FindOneByTokenAndNotExpired(ctx context.Context, token string) (*entity.Session, error) {
 	driver := transaction.GetDriver(ctx, r.db)
 	var model model.SessionModel
-	if err := driver.QueryRowxContext(ctx, `SELECT account_id, token, expires_at FROM sessions WHERE token = ?;`, token).StructScan(&model); err != nil {
+	if err := driver.QueryRowxContext(ctx, `SELECT account_id, token, expires_at FROM sessions WHERE token = ? AND expires_at > NOW(6);`, token).StructScan(&model); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}

--- a/internal/app/api/usecase/session.go
+++ b/internal/app/api/usecase/session.go
@@ -86,7 +86,7 @@ func (u *sessionUsecase) Authenticate(ctx context.Context, token string) (*dto.A
 	var account *entity.Account
 
 	if err := u.transactionObj.Transaction(ctx, func(ctx context.Context) error {
-		session, err := u.sessionRepo.FindOneByToken(ctx, token)
+		session, err := u.sessionRepo.FindOneByTokenAndNotExpired(ctx, token)
 		if err != nil {
 			return err
 		}

--- a/internal/app/api/usecase/session_test.go
+++ b/internal/app/api/usecase/session_test.go
@@ -380,7 +380,7 @@ func TestSession_Authenticate(t *testing.T) {
 			setMockSessionRepo: func(ctx context.Context, sessionRepo *repository.MockSessionRepository) {
 				sessionRepo.
 					EXPECT().
-					FindOneByToken(ctx, gomock.Any()).
+					FindOneByTokenAndNotExpired(ctx, gomock.Any()).
 					Return(session, nil).
 					Times(1)
 			},
@@ -409,7 +409,7 @@ func TestSession_Authenticate(t *testing.T) {
 			setMockSessionRepo: func(ctx context.Context, sessionRepo *repository.MockSessionRepository) {
 				sessionRepo.
 					EXPECT().
-					FindOneByToken(ctx, gomock.Any()).
+					FindOneByTokenAndNotExpired(ctx, gomock.Any()).
 					Return(nil, nil).
 					Times(1)
 			},
@@ -432,7 +432,7 @@ func TestSession_Authenticate(t *testing.T) {
 			setMockSessionRepo: func(ctx context.Context, sessionRepo *repository.MockSessionRepository) {
 				sessionRepo.
 					EXPECT().
-					FindOneByToken(ctx, gomock.Any()).
+					FindOneByTokenAndNotExpired(ctx, gomock.Any()).
 					Return(session, nil).
 					Times(1)
 			},
@@ -461,7 +461,7 @@ func TestSession_Authenticate(t *testing.T) {
 			setMockSessionRepo: func(ctx context.Context, sessionRepo *repository.MockSessionRepository) {
 				sessionRepo.
 					EXPECT().
-					FindOneByToken(ctx, gomock.Any()).
+					FindOneByTokenAndNotExpired(ctx, gomock.Any()).
 					Return(nil, sql.ErrConnDone).
 					Times(1)
 			},
@@ -484,7 +484,7 @@ func TestSession_Authenticate(t *testing.T) {
 			setMockSessionRepo: func(ctx context.Context, sessionRepo *repository.MockSessionRepository) {
 				sessionRepo.
 					EXPECT().
-					FindOneByToken(ctx, gomock.Any()).
+					FindOneByTokenAndNotExpired(ctx, gomock.Any()).
 					Return(session, nil).
 					Times(1)
 			},

--- a/test/mock/domain/repository/session.go
+++ b/test/mock/domain/repository/session.go
@@ -71,19 +71,19 @@ func (mr *MockSessionRepositoryMockRecorder) FindOneByAccountID(arg0, arg1 any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByAccountID", reflect.TypeOf((*MockSessionRepository)(nil).FindOneByAccountID), arg0, arg1)
 }
 
-// FindOneByToken mocks base method.
-func (m *MockSessionRepository) FindOneByToken(arg0 context.Context, arg1 string) (*entity.Session, error) {
+// FindOneByTokenAndNotExpired mocks base method.
+func (m *MockSessionRepository) FindOneByTokenAndNotExpired(arg0 context.Context, arg1 string) (*entity.Session, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindOneByToken", arg0, arg1)
+	ret := m.ctrl.Call(m, "FindOneByTokenAndNotExpired", arg0, arg1)
 	ret0, _ := ret[0].(*entity.Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FindOneByToken indicates an expected call of FindOneByToken.
-func (mr *MockSessionRepositoryMockRecorder) FindOneByToken(arg0, arg1 any) *gomock.Call {
+// FindOneByTokenAndNotExpired indicates an expected call of FindOneByTokenAndNotExpired.
+func (mr *MockSessionRepositoryMockRecorder) FindOneByTokenAndNotExpired(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByToken", reflect.TypeOf((*MockSessionRepository)(nil).FindOneByToken), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByTokenAndNotExpired", reflect.TypeOf((*MockSessionRepository)(nil).FindOneByTokenAndNotExpired), arg0, arg1)
 }
 
 // Save mocks base method.


### PR DESCRIPTION
# Issue
- close: #104 

# 確認事項
- 有効期限切れのTokenでのアクセス時に401が返却されることを確認
- 有効期間内のTokenでのアクセス時に正常にリクエストが処理されることを確認
